### PR TITLE
add explicit model installation step

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ th download-content.lua
 
 In order to run the demo simply type:
 ```bash
+mkdir models && wget https://www.adrianbulat.com/downloads/BinaryHumanPose/facealignment_binary_aflw.t7 -O models/facealignment_binary_aflw.t7
 th main.lua
 ```
 


### PR DESCRIPTION
Running `th main.lua` tells one where the model should be.  This simply adds the setup to the readme.

Sample error:
```
/torch/install/bin/luajit: cannot open <models/facealignment_binary_aflw.t7> in mode r  at /torch/pkg/torch/lib/TH/THDiskFile.c:673
stack traceback:
	[C]: at 0x08206350
	[C]: in function 'DiskFile'
	/Users/dhirvonen/torch/install/share/lua/5.1/torch/File.lua:405: in function 'load'
	main.lua:25: in main chunk
	[C]: in function 'dofile'
	...onen/torch/install/lib/luarocks/rocks/trepl/scm-1/bin/th:150: in main chunk
	[C]: at 0x01080e2350
```